### PR TITLE
feat: add scroll reveal animations

### DIFF
--- a/Cozik/css/styles.css
+++ b/Cozik/css/styles.css
@@ -10994,3 +10994,23 @@ header.masthead h1, header.masthead .h1 {
   opacity: 1;
 }
 
+/* Základ pro odhalování */
+.reveal {
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 0.5s ease, transform 0.5s ease;
+}
+
+.reveal.visible {
+  opacity: 1;
+  transform: none;
+}
+
+/* Bez animací pro uživatele s omezením pohybu */
+@media (prefers-reduced-motion: reduce) {
+  .reveal {
+    transition: none !important;
+    transform: none !important;
+  }
+}
+

--- a/Cozik/index.html
+++ b/Cozik/index.html
@@ -267,5 +267,6 @@
         <!-- * * Activate your form at https://startbootstrap.com/solution/contact-forms * *-->
         <!-- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *-->
         <script src="https://cdn.startbootstrap.com/sb-forms-latest.js"></script>
+        <script src="/js/reveal.js" defer></script>
     </body>
 </html>

--- a/Cozik/js/reveal.js
+++ b/Cozik/js/reveal.js
@@ -1,0 +1,74 @@
+(function () {
+  const onReady = () => {
+    const root = document.querySelector('main') || document.body;
+
+    // vyber kandidáty (text a běžný obsah), ale ne uvnitř header/nav/footer
+    const blockSelectors = 'h1,h2,h3,h4,h5,h6,p,li,blockquote,figure,article,section,.card,.btn,button,a,dt,dd';
+    const excluded = ['header', 'nav', 'footer'];
+    const isInExcluded = (el) => excluded.some(sel => el.closest(sel));
+
+    const candidates = Array.from(root.querySelectorAll(blockSelectors))
+      .filter(el => !isInExcluded(el));
+
+    // přidej .reveal všem kandidátům
+    candidates.forEach(el => el.classList.add('reveal'));
+
+    // HERO: nad hlavičkou stránky – zkus najít hero kontejner
+    const hero =
+      root.querySelector('.hero') ||
+      document.querySelector('[data-hero]') ||
+      document.querySelector('header.hero') ||
+      document.querySelector('.masthead') ||
+      document.querySelector('.jumbotron') ||
+      // fallback: první viditelná sekce
+      root.querySelector('section') ||
+      null;
+
+    const heroEls = hero
+      ? Array.from(hero.querySelectorAll('.reveal'))
+      : [];
+
+    // nejdřív je všechno neviditelné; po 0,5 s začni zobrazovat hero (trvá 0,5 s)
+    setTimeout(() => {
+      heroEls.forEach((el, i) => {
+        // malý „stagger“, aby šel nejdřív nadpis, pak podnadpis atd.
+        setTimeout(() => el.classList.add('visible'), i * 80);
+      });
+    }, 500);
+
+    // IO pro zbytek stránky (zobrazit jednou, jakmile vstoupí do viewportu)
+    const observer = 'IntersectionObserver' in window
+      ? new IntersectionObserver((entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              const el = entry.target;
+              el.classList.add('visible');
+              observer.unobserve(el);
+            }
+          });
+        }, {
+          root: null,
+          threshold: 0.25,
+          rootMargin: '0px 0px -10% 0px'
+        })
+      : null;
+
+    if (observer) {
+      // nepozoruj hero prvky (ty už řešíme výše)
+      const toObserve = candidates.filter(el => !hero || !hero.contains(el));
+      toObserve.forEach(el => observer.observe(el));
+    } else {
+      // fallback bez IO: vše rovnou viditelné (krom zpožděného hero)
+      candidates
+        .filter(el => !hero || !hero.contains(el))
+        .forEach(el => el.classList.add('visible'));
+    }
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', onReady);
+  } else {
+    onReady();
+  }
+})();
+

--- a/css/styles.css
+++ b/css/styles.css
@@ -10994,3 +10994,23 @@ header.masthead h1, header.masthead .h1 {
   opacity: 1;
 }
 
+/* Základ pro odhalování */
+.reveal {
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 0.5s ease, transform 0.5s ease;
+}
+
+.reveal.visible {
+  opacity: 1;
+  transform: none;
+}
+
+/* Bez animací pro uživatele s omezením pohybu */
+@media (prefers-reduced-motion: reduce) {
+  .reveal {
+    transition: none !important;
+    transform: none !important;
+  }
+}
+

--- a/index.html
+++ b/index.html
@@ -267,5 +267,6 @@
         <!-- * * Activate your form at https://startbootstrap.com/solution/contact-forms * *-->
         <!-- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *-->
         <script src="https://cdn.startbootstrap.com/sb-forms-latest.js"></script>
+        <script src="/js/reveal.js" defer></script>
     </body>
 </html>

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -1,0 +1,74 @@
+(function () {
+  const onReady = () => {
+    const root = document.querySelector('main') || document.body;
+
+    // vyber kandidáty (text a běžný obsah), ale ne uvnitř header/nav/footer
+    const blockSelectors = 'h1,h2,h3,h4,h5,h6,p,li,blockquote,figure,article,section,.card,.btn,button,a,dt,dd';
+    const excluded = ['header', 'nav', 'footer'];
+    const isInExcluded = (el) => excluded.some(sel => el.closest(sel));
+
+    const candidates = Array.from(root.querySelectorAll(blockSelectors))
+      .filter(el => !isInExcluded(el));
+
+    // přidej .reveal všem kandidátům
+    candidates.forEach(el => el.classList.add('reveal'));
+
+    // HERO: nad hlavičkou stránky – zkus najít hero kontejner
+    const hero =
+      root.querySelector('.hero') ||
+      document.querySelector('[data-hero]') ||
+      document.querySelector('header.hero') ||
+      document.querySelector('.masthead') ||
+      document.querySelector('.jumbotron') ||
+      // fallback: první viditelná sekce
+      root.querySelector('section') ||
+      null;
+
+    const heroEls = hero
+      ? Array.from(hero.querySelectorAll('.reveal'))
+      : [];
+
+    // nejdřív je všechno neviditelné; po 0,5 s začni zobrazovat hero (trvá 0,5 s)
+    setTimeout(() => {
+      heroEls.forEach((el, i) => {
+        // malý „stagger“, aby šel nejdřív nadpis, pak podnadpis atd.
+        setTimeout(() => el.classList.add('visible'), i * 80);
+      });
+    }, 500);
+
+    // IO pro zbytek stránky (zobrazit jednou, jakmile vstoupí do viewportu)
+    const observer = 'IntersectionObserver' in window
+      ? new IntersectionObserver((entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              const el = entry.target;
+              el.classList.add('visible');
+              observer.unobserve(el);
+            }
+          });
+        }, {
+          root: null,
+          threshold: 0.25,
+          rootMargin: '0px 0px -10% 0px'
+        })
+      : null;
+
+    if (observer) {
+      // nepozoruj hero prvky (ty už řešíme výše)
+      const toObserve = candidates.filter(el => !hero || !hero.contains(el));
+      toObserve.forEach(el => observer.observe(el));
+    } else {
+      // fallback bez IO: vše rovnou viditelné (krom zpožděného hero)
+      candidates
+        .filter(el => !hero || !hero.contains(el))
+        .forEach(el => el.classList.add('visible'));
+    }
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', onReady);
+  } else {
+    onReady();
+  }
+})();
+


### PR DESCRIPTION
## Summary
- add reusable reveal CSS classes with reduced-motion fallback
- auto-apply reveal animations with IntersectionObserver and delayed hero reveal
- load reveal script on each page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e1cd3a70883319bd4e9b69d390104