### PR TITLE
Enable bidirectional reveal animations

### DIFF
--- a/Cozik/css/styles.css
+++ b/Cozik/css/styles.css
@@ -11011,6 +11011,7 @@ header.masthead h1, header.masthead .h1 {
   .reveal {
     transition: none !important;
     transform: none !important;
+    opacity: 1 !important;
   }
 }
 

--- a/Cozik/js/reveal.js
+++ b/Cozik/js/reveal.js
@@ -36,24 +36,22 @@
       });
     }, 500);
 
-    // IO pro zbytek stránky (zobrazit jednou, jakmile vstoupí do viewportu)
-    const observer = 'IntersectionObserver' in window
-      ? new IntersectionObserver((entries) => {
-          entries.forEach((entry) => {
-            if (entry.isIntersecting) {
-              const el = entry.target;
-              el.classList.add('visible');
-              observer.unobserve(el);
-            }
-          });
-        }, {
-          root: null,
-          threshold: 0.25,
-          rootMargin: '0px 0px -10% 0px'
-        })
-      : null;
+    // IO pro zbytek stránky (zobrazit pokaždé, když vstoupí do/odejde z viewportu)
+    if ('IntersectionObserver' in window) {
+      const observer = new IntersectionObserver((entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('visible');
+          } else {
+            entry.target.classList.remove('visible');
+          }
+        });
+      }, {
+        root: null,
+        threshold: 0.25,
+        rootMargin: '0px 0px -10% 0px'
+      });
 
-    if (observer) {
       // nepozoruj hero prvky (ty už řešíme výše)
       const toObserve = candidates.filter(el => !hero || !hero.contains(el));
       toObserve.forEach(el => observer.observe(el));

--- a/css/styles.css
+++ b/css/styles.css
@@ -11011,6 +11011,7 @@ header.masthead h1, header.masthead .h1 {
   .reveal {
     transition: none !important;
     transform: none !important;
+    opacity: 1 !important;
   }
 }
 

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -36,24 +36,22 @@
       });
     }, 500);
 
-    // IO pro zbytek stránky (zobrazit jednou, jakmile vstoupí do viewportu)
-    const observer = 'IntersectionObserver' in window
-      ? new IntersectionObserver((entries) => {
-          entries.forEach((entry) => {
-            if (entry.isIntersecting) {
-              const el = entry.target;
-              el.classList.add('visible');
-              observer.unobserve(el);
-            }
-          });
-        }, {
-          root: null,
-          threshold: 0.25,
-          rootMargin: '0px 0px -10% 0px'
-        })
-      : null;
+    // IO pro zbytek stránky (zobrazit pokaždé, když vstoupí do/odejde z viewportu)
+    if ('IntersectionObserver' in window) {
+      const observer = new IntersectionObserver((entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('visible');
+          } else {
+            entry.target.classList.remove('visible');
+          }
+        });
+      }, {
+        root: null,
+        threshold: 0.25,
+        rootMargin: '0px 0px -10% 0px'
+      });
 
-    if (observer) {
       // nepozoruj hero prvky (ty už řešíme výše)
       const toObserve = candidates.filter(el => !hero || !hero.contains(el));
       toObserve.forEach(el => observer.observe(el));


### PR DESCRIPTION
## Summary
- Reconfigure IntersectionObserver to toggle `.visible` when elements enter or leave the viewport, letting reveal animations repeat as users scroll.
- Honor reduced motion preferences by forcing revealed elements fully opaque without transitions.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e2125361c83319bd00d97c710a575