### PR TITLE
Fix typo in material quality section

### DIFF
--- a/Cozik/index.html
+++ b/Cozik/index.html
@@ -82,7 +82,7 @@
                         <div class="mt-5">
                             <div class="mb-2"><i class="bi-gem fs-1 text-primary"></i></div>
                             <h3 class="h4 mb-2">Kvalita materiálu</h3>
-                            <p class="text-muted mb-0">Naše jantarové kousky jsou pečlivě vybírány a pocházejí z ověřených, kvalitních zdrojů. Každý kousek je přírodní, což zaručuje jeho jedinečnost a autentickost.</p>
+                            <p class="text-muted mb-0">Naše jantarové kousky jsou pečlivě vybírány a pocházejí z ověřených, kvalitních zdrojů. Každý kousek je přírodní, což zaručuje jeho jedinečnost a autentičnost.</p>
                         </div>
                     </div>
                     <div class="col-lg-3 col-md-6 text-center">

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
                         <div class="mt-5">
                             <div class="mb-2"><i class="bi-gem fs-1 text-primary"></i></div>
                             <h3 class="h4 mb-2">Kvalita materiálu</h3>
-                            <p class="text-muted mb-0">Naše jantarové kousky jsou pečlivě vybírány a pocházejí z ověřených, kvalitních zdrojů. Každý kousek je přírodní, což zaručuje jeho jedinečnost a autentickost.</p>
+                            <p class="text-muted mb-0">Naše jantarové kousky jsou pečlivě vybírány a pocházejí z ověřených, kvalitních zdrojů. Každý kousek je přírodní, což zaručuje jeho jedinečnost a autentičnost.</p>
                         </div>
                     </div>
                     <div class="col-lg-3 col-md-6 text-center">


### PR DESCRIPTION
## Summary
- Correct typo in Material Quality section: "autentickost" → "autentičnost".

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ac14732083319f124401229fb76b