### PR TITLE
Display email and phone side by side in contact section

### DIFF
--- a/Cozik/index.html
+++ b/Cozik/index.html
@@ -187,11 +187,13 @@
                         
                     </div>
                 </div>
-                <div class="row gx-4 gx-lg-5 justify-content-center">
+                <div class="row gx-4 gx-lg-5 justify-content-between">
                     <div class="col-lg-4 text-center mb-5 mb-lg-0">
                         <i class="bi-envelope fs-2 mb-3 text-muted"></i>
                         <div><a href="mailto:jantary@jantary.cz">jantary@jantary.cz</a></div>
-                        <i class="bi-phone fs-2 mb-3 text-muted mt-4"></i>
+                    </div>
+                    <div class="col-lg-4 text-center mb-5 mb-lg-0">
+                        <i class="bi-phone fs-2 mb-3 text-muted"></i>
                         <div>+420 723 809 033</div>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -187,11 +187,13 @@
                         
                     </div>
                 </div>
-                <div class="row gx-4 gx-lg-5 justify-content-center">
+                <div class="row gx-4 gx-lg-5 justify-content-between">
                     <div class="col-lg-4 text-center mb-5 mb-lg-0">
                         <i class="bi-envelope fs-2 mb-3 text-muted"></i>
                         <div><a href="mailto:jantary@jantary.cz">jantary@jantary.cz</a></div>
-                        <i class="bi-phone fs-2 mb-3 text-muted mt-4"></i>
+                    </div>
+                    <div class="col-lg-4 text-center mb-5 mb-lg-0">
+                        <i class="bi-phone fs-2 mb-3 text-muted"></i>
                         <div>+420 723 809 033</div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- Arrange contact email and phone into two centered columns to appear side by side

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ad792be88331ba656fe8cefa912c