### PR TITLE
fix: correct path to initial amber background

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -10929,7 +10929,7 @@ hr.divider-light {
 header.masthead {
   padding-top: 10rem;
   padding-bottom: calc(10rem - 4.5rem);
-  background: linear-gradient(to bottom, rgba(92, 77, 66, 0.4) 0%, rgba(92, 77, 66, 0.8) 100%), url("../assets/img/Uvodni_jantary.webp");
+  background: linear-gradient(to bottom, rgba(92, 77, 66, 0.4) 0%, rgba(92, 77, 66, 0.8) 100%), url("../Cozik/assets/img/Uvodni_jantary.webp");
   background-position: center;
   background-repeat: no-repeat;
   background-attachment: scroll;


### PR DESCRIPTION
## Summary
- fix background path for masthead by pointing to the existing image in Cozik/assets

## Testing
- `npm test` (fails: ENOENT could not read package.json)
- `python - <<'PY'
from PIL import Image
Image.open('Cozik/assets/img/Uvodni_jantary.webp').verify()
print('Image verified')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b0afafabbc8331ab6df79ba14cb080